### PR TITLE
fix: replace hardcoded 127.0.0.1 IP with VITE_API_URL env variable

### DIFF
--- a/client/src/pages/CoursePreview.tsx
+++ b/client/src/pages/CoursePreview.tsx
@@ -12,7 +12,7 @@ export const CoursePreview = () => {
   const fetchCourse = () => {
     console.log("Wysyłam zapytanie o kurs z tokenem:", token ? "TAK" : "NIE");
     
-    fetch(`http://127.0.0.1:5000/api/courses/${id}`, {
+    fetch(`${import.meta.env.VITE_API_URL}/api/courses/${id}`, {
       headers: token ? { 'Authorization': `Bearer ${token}` } : {}
     })
       .then(res => res.json())
@@ -30,7 +30,7 @@ export const CoursePreview = () => {
   useEffect(() => {
     const isSuccess = searchParams.get('success');
     if (isSuccess && token && course) {
-      fetch('http://127.0.0.1:5000/api/payments/academic-success', {
+      fetch(`${import.meta.env.VITE_API_URL}/api/payments/academic-success`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Tytuł PR: fix: Zamiana sztywnych adresów IP 127.0.0.1 na zmienną środowiskową

Opis zmian:
Szybki hotfix rozwiązujący błąd ERR_CONNECTION_REFUSED na środowisku produkcyjnym Vercel.
Podczas poprzedniej refaktoryzacji pominięto pliki (m.in. CoursePreview.tsx), w których adres API był zadeklarowany z użyciem adresu IP (127.0.0.1:5000) zamiast localhost. Zapytania te zostały ustandaryzowane i podpięte pod globalną zmienną środowiskową ${import.meta.env.VITE_API_URL}.